### PR TITLE
add column filters to 'Download glossary', update tests and docs

### DIFF
--- a/Apps.NotionOAuth/Apps.NotionOAuth.csproj
+++ b/Apps.NotionOAuth/Apps.NotionOAuth.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
 	 <Product>Notion</Product>
 	 <Description>Productivity and note-taking web application</Description>
-	 <Version>1.2.10</Version>
+	 <Version>1.2.11</Version>
 	 <AssemblyName>Apps.NotionOAuth</AssemblyName>
   </PropertyGroup>
   <ItemGroup>

--- a/Apps.NotionOAuth/Models/Request/DataSource/DownloadGlossaryRequest.cs
+++ b/Apps.NotionOAuth/Models/Request/DataSource/DownloadGlossaryRequest.cs
@@ -1,7 +1,6 @@
-﻿using Apps.NotionOAuth.DataSourceHandlers;
-using Apps.NotionOAuth.DataSourceHandlers.DatabaseProperties;
-using Blackbird.Applications.Sdk.Common;
+﻿using Blackbird.Applications.Sdk.Common;
 using Blackbird.Applications.Sdk.Common.Dynamic;
+using Apps.NotionOAuth.DataSourceHandlers.DatabaseProperties;
 
 namespace Apps.NotionOAuth.Models.Request.DataSource;
 
@@ -31,4 +30,11 @@ public class DownloadGlossaryRequest
 
     [Display("Glossary source description")]
     public string? SourceDescription { get; set; }
+
+    [Display("Filter fields", Description = "List of properties to filter by. Input the filter values in the same order as these fields")]
+    [DataSource(typeof(StringDatabasePropertyDataHandler))]
+    public List<string>? FilterFields { get; set; }
+
+    [Display("Filter values")]
+    public List<string>? FilterValues { get; set; }
 }

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Notion is a note-taking and idea-organizing platform. This Notion application pr
 
 - **Download glossary** downloads data source pages into an interoperable glosary.
 
+> Filtering logic for the 'Download glossary' action includes all entries that match the filter criteria and assembles them into a glossary file. For each filter field provided, you must provide a corresponding filter value.
+
 ## Events
 
 ### Pages

--- a/Tests.Notion/GlossaryActionsTests.cs
+++ b/Tests.Notion/GlossaryActionsTests.cs
@@ -15,15 +15,10 @@ public class GlossaryActionsTests : TestBase
         // Arrange
         var dataSource = new DataSourceRequest()
         {
-            DataSourceId = "cdc4b903-4226-476f-bed2-67c635cfac2a",
+            DataSourceId = "2d887f55-25f0-80ec-8fe5-000b81251270",
         };
         var input = new DownloadGlossaryRequest
         {
-            NoteProperty = "uQDf",
-            DefaultLocale = "en-US",
-            DomainProperty = "Kqj%7C",
-            DefinitionProperty = "b%5EAC",
-            PropertiesAsTargetLanguages = ["DCWl", "%40%60%7CV"]
         };
 
         // Act
@@ -39,23 +34,21 @@ public class GlossaryActionsTests : TestBase
         // Arrange
         var dataSource = new DataSourceRequest()
         {
-            DataSourceId = "2b8a9644-cf02-80e7-abed-000b68742d53"
+            DataSourceId = "2d887f55-25f0-80ec-8fe5-000b81251270",
         };
         var input = new DownloadGlossaryRequest
         {
-            PropertiesAsTargetLanguages = ["yX%3BK", "%7C%3Do%3F", "UoW%40"], // pt-BR, es, de
-            DefaultLocale = "en_US",
-            DefinitionProperty = "VO%5Dw",
-            NoteProperty = "%3FFhs",
-            DomainProperty = "GZoJ",
-            Title = "Glossary Page (all inputs)",
-            SourceDescription = "This is a sample glossary."
+            PropertiesAsTargetLanguages = ["mFyX", "F%3EmZ"],
+            Title = "Glossary Page",
+            SourceDescription = "This is a sample glossary.",
+            FilterFields = ["%3Ea%60b", "%3Ea%60b", "SPMh"],
+            FilterValues = ["Approved", "Draft", "123@gmail.com"]
         };
 
         // Act
         var result = await _actions.DownloadGlossary(dataSource, input);
 
         // Assert
-        Assert.AreEqual("Glossary Page (all inputs).tbx", result.Glossary.Name);
+        Assert.AreEqual("Glossary Page.tbx", result.Glossary.Name);
     }
 }


### PR DESCRIPTION
Added filtering for the 'Download glossary' action